### PR TITLE
fixed typo in shortened name of broomfield county.

### DIFF
--- a/covid_model/run_fit.py
+++ b/covid_model/run_fit.py
@@ -17,7 +17,7 @@ regions = {
   "ad": "Adams County",
   "ar": "Arapahoe County",
   "bo": "Boulder County",
-  "br": "Broomfield County",
+  "brm": "Broomfield County",
   "den": "Denver County",
   "doug": "Douglas County",
   "ep": "El Paso County",

--- a/tests/test_disconnected_regional_model.py
+++ b/tests/test_disconnected_regional_model.py
@@ -37,8 +37,8 @@ class MyTestCase(unittest.TestCase):
     def test_bo(self):
         self.region_test("bo")
 
-    def test_br(self):
-        self.region_test("br")
+    def test_brm(self):
+        self.region_test("brm")
 
     def test_den(self):
         self.region_test("den")


### PR DESCRIPTION
Fixed typo for Broomfield County short name. 